### PR TITLE
Fix link in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -18,7 +18,7 @@ Press This is a redesign of the Press This bookmarklet with a focus on automatio
 
 == Contributing ==
 
-You can see discussion and progress at [corepressthis.wordpress.com](corepressthis.wordpress.com).
+You can see discussion and progress at [corepressthis.wordpress.com](http://corepressthis.wordpress.com).
 
 Development of this plugin is done on [Github](https://github.com/MichaelArestad/Press-This). Pull requests welcome.
 


### PR DESCRIPTION
Add protocol to the link to corepressthis.wordpress.com so it won't 404 as a relative link within wordpress.org.