### PR TITLE
Enable bookmarklet for Firefox

### DIFF
--- a/js/bookmarklet.js
+++ b/js/bookmarklet.js
@@ -123,7 +123,7 @@ var WpPressThis_Bookmarklet = function(pt_url) {
 	if (es.length && es.length > 512)
 		fAdd('s', s);
 
-	if ( navigator && navigator.userAgent && navigator.userAgent.length && ! navigator.userAgent.match(/firefox\//i) ) {
+	if ( navigator && navigator.userAgent && navigator.userAgent.length ) {
 		tnu = 'about:blank';
 		fs = true;
 		f.setAttribute('method', 'POST');
@@ -133,6 +133,8 @@ var WpPressThis_Bookmarklet = function(pt_url) {
 
 	w.open(tnu, tn, "width=500,height=700");
 
-	if ( true == fs )
+	if ( true == fs ) {
+		d.body.appendChild( f );
 		f.submit();
+	}
 };


### PR DESCRIPTION
When remove the firefox skip the form doesn't submit because it's not
part of the document. Appending the form to the document before submitting
seems to clear this up.

![screen shot 2015-01-21 at 8 00 53 pm](https://cloud.githubusercontent.com/assets/408862/5849833/46927a90-a1a8-11e4-9b64-2a8961fdd8e3.png)

The only difference between Firefox and Chrome seems to be that Firefox triggers an actual popup instead of just showing a warning in the location bar.