### PR TITLE
Modifies outputted HTML ids to classes when to output valid HTML

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -130,14 +130,14 @@
 
 				// Wrap suggested content in blockquote tag, if we have any.
 				content = ( (content.length)
-					? '<blockquote id="wppt_suggested_content">' + html_encode( content.replace(/\\/g, '') ) + '</blockquote>'
+					? '<blockquote class="wppt_suggested_content">' + html_encode( content.replace(/\\/g, '') ) + '</blockquote>'
 					: '' );
 
 				// Add a source attribution if there is one available.
 				if ( ( ( title.length && __( 'new-post' ) != title ) || site_name.length ) && url.length ) {
 					content += '<p class="wppt_source">'
 					+ __( 'source' )
-					+ ' <cite id="wppt_suggested_content_source"><a href="'+ encodeURI( url ) +'">'+ html_encode( title || site_name ) +'</a></cite>'
+					+ ' <cite class="wppt_suggested_content_source"><a href="'+ encodeURI( url ) +'">'+ html_encode( title || site_name ) +'</a></cite>'
 					+ '</p>';
 				}
 


### PR DESCRIPTION
Previously, PT outputted HTML id attributes, which will cause invalid HTML on archive pages with multiple PT posts listed. Changes it over to a class attribute. I did not notice any CSS/SCSS that used these ids.

Fixes MichaelArestad/Press-This#14