### PR TITLE
Issue #67. Keyboard Tab Navigation.

### DIFF
--- a/css/press-this.css
+++ b/css/press-this.css
@@ -513,9 +513,7 @@ big {
   color: #fff;
 }
 
-.tagsdiv .newtag:focus, .tagcloud-link:focus, .the-tagcloud a:focus, .scan__url:focus, .post__title:active, .post__title:focus,
-.post__title-placeholder:active,
-.post__title-placeholder:focus, .suggested-media-thumbnail:focus, .modal-close:focus {
+.suggested-media-thumbnail:focus {
   -webkit-box-shadow: inset 0px -5px 0 #2ea2cc;
   box-shadow: inset 0px -5px 0 #2ea2cc;
 }
@@ -681,7 +679,8 @@ object {
 .post-format {
   width: 0;
   height: 0;
-  float: left;
+  position: absolute;
+  top: -9999px;
 }
 
 .post-format-icon {
@@ -773,6 +772,7 @@ object {
   background: #e5e5e5;
 }
 .tagsdiv .tagadd:focus {
+  outline: 0;
   background: #2ea2cc;
   color: #fff;
 }
@@ -958,13 +958,6 @@ input.newtag:focus ~ div.taghint {
   min-width: 16px;
   -webkit-appearance: none;
   appearance: none;
-  width: 100%;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-}
-.categories-select input:focus {
-  border-bottom: 3px solid #2ea2cc;
 }
 .categories-select input:checked:after {
   display: inline-block;
@@ -1097,20 +1090,13 @@ html {
     font-size: 14px;
   }
 }
-.current-site a {
+.current-site span {
   color: #ededed;
-  text-decoration: none;
-}
-.current-site a:hover {
-  color: #fff;
 }
 @media (max-width: 320px) {
-  .current-site a {
+  .current-site span {
     color: #3f3f3f;
     font-weight: 600;
-  }
-  .current-site a:hover {
-    color: #2ea2cc;
   }
 }
 .current-site .dashicons-wordpress {
@@ -1282,6 +1268,9 @@ html {
 .post__title:active, .post__title:focus,
 .post__title-placeholder:active,
 .post__title-placeholder:focus {
+  outline: 0;
+  -webkit-box-shadow: inset 0px -5px 0 #2ea2cc;
+  box-shadow: inset 0px -5px 0 #2ea2cc;
   border-color: #2ea2cc;
 }
 @media (max-height: 400px) {
@@ -1578,8 +1567,13 @@ html {
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  -webkit-transition: all .3s ease-in-out;
-  transition: all .3s ease-in-out;
+  -webkit-transition: -webkit-transform .3s ease-in-out;
+  transition: transform .3s ease-in-out;
+}
+.post-options .post-option:focus {
+  outline: 0;
+  -webkit-box-shadow: inset 5px 0 0 #2ea2cc;
+  box-shadow: inset 5px 0 0 #2ea2cc;
 }
 .is-hidden .post-option {
   right: 100%;
@@ -1634,6 +1628,11 @@ html {
   padding: 13px 14px;
   border-bottom: 1px solid #e5e5e5;
   text-decoration: none;
+}
+.modal-close:focus {
+  outline: 0;
+  -webkit-box-shadow: inset 5px 0 0 #2ea2cc;
+  box-shadow: inset 5px 0 0 #2ea2cc;
 }
 
 .setting-title {

--- a/css/press-this.css
+++ b/css/press-this.css
@@ -513,6 +513,13 @@ big {
   color: #fff;
 }
 
+.tagsdiv .newtag:focus, .tagcloud-link:focus, .the-tagcloud a:focus, .scan__url:focus, .post__title:active, .post__title:focus,
+.post__title-placeholder:active,
+.post__title-placeholder:focus, .suggested-media-thumbnail:focus, .modal-close:focus {
+  -webkit-box-shadow: inset 0px -5px 0 #2ea2cc;
+  box-shadow: inset 0px -5px 0 #2ea2cc;
+}
+
 .button--subtle {
   background: none;
   border: 0;
@@ -672,7 +679,9 @@ object {
 }
 
 .post-format {
-  display: none;
+  width: 0;
+  height: 0;
+  float: left;
 }
 
 .post-format-icon {
@@ -763,6 +772,10 @@ object {
   padding: 0 16px;
   background: #e5e5e5;
 }
+.tagsdiv .tagadd:focus {
+  background: #2ea2cc;
+  color: #fff;
+}
 .tagsdiv .howto {
   color: #727272;
   font-style: italic;
@@ -847,6 +860,7 @@ input.newtag:focus ~ div.taghint {
   text-indent: 0;
   overflow: hidden;
   position: absolute;
+  outline: 0;
 }
 .tagchecklist .ntdelbutton:before {
   content: '\f153';
@@ -861,6 +875,9 @@ input.newtag:focus ~ div.taghint {
   speak: none;
   -webkit-font-smoothing: antialiased !important;
 }
+.tagchecklist .ntdelbutton:focus:before {
+  color: #2ea2cc;
+}
 
 .tagsdiv + p {
   margin: 0;
@@ -870,6 +887,7 @@ input.newtag:focus ~ div.taghint {
   display: block;
   padding: 0 16px;
   text-decoration: none;
+  outline: 0;
 }
 
 .popular-tags {
@@ -889,6 +907,7 @@ input.newtag:focus ~ div.taghint {
 }
 .the-tagcloud a {
   text-decoration: none;
+  outline: 0;
 }
 
 .tagcloud h3 {
@@ -939,14 +958,20 @@ input.newtag:focus ~ div.taghint {
   min-width: 16px;
   -webkit-appearance: none;
   appearance: none;
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+.categories-select input:focus {
+  border-bottom: 3px solid #2ea2cc;
 }
 .categories-select input:checked:after {
   display: inline-block;
   content: "\f147";
   position: absolute;
-  top: 50%;
+  top: -1.65em;
   right: 15px;
-  margin-top: -10px;
   width: 20px;
   height: 20px;
   margin-right: 10px;
@@ -1257,9 +1282,6 @@ html {
 .post__title:active, .post__title:focus,
 .post__title-placeholder:active,
 .post__title-placeholder:focus {
-  outline: 0;
-  -webkit-box-shadow: inset 0px -3px 0 #2ea2cc;
-  box-shadow: inset 0px -3px 0 #2ea2cc;
   border-color: #2ea2cc;
 }
 @media (max-height: 400px) {

--- a/css/press-this.css
+++ b/css/press-this.css
@@ -513,11 +513,6 @@ big {
   color: #fff;
 }
 
-.suggested-media-thumbnail:focus {
-  -webkit-box-shadow: inset 0px -5px 0 #2ea2cc;
-  box-shadow: inset 0px -5px 0 #2ea2cc;
-}
-
 .button--subtle {
   background: none;
   border: 0;

--- a/js/app.js
+++ b/js/app.js
@@ -399,7 +399,7 @@
 			function render_suggested_title() {
 				var title = suggested_title_str || '';
 
-				if ( !has_empty_title_str ) {
+				if ( ! has_empty_title_str ) {
 					$('#wppt_title_field').val( title );
 					$('#wppt_title_container').text( title )
 					$('.post__title-placeholder').addClass('screen-reader-text');
@@ -452,7 +452,8 @@
 
 						$('<div></div>', {
 							'id': 'embed-' + i + '-container',
-							'class': 'suggested-media-thumbnail suggested-media--embed'
+							'class': 'suggested-media-thumbnail suggested-media--embed',
+							'tabindex': '0'
 						}).css({
 							'background-image': 'url(' + display_src + ')'
 						}).click(function () {
@@ -477,11 +478,14 @@
 						$('<img />', {
 							'src': display_src,
 							'id': 'img-' + i + '-container',
-							'class': 'suggested-media-thumbnail'
+							'class': 'suggested-media-thumbnail',
+							'tabindex': '0'
 						}).css({
 							'background-image': 'url(' + display_src + ')'
-						}).click(function () {
-							insert_selected_media('img', src, data.u);
+						}).on('click keypress', function (e) {
+							if ( e.type === 'click' || e.which === 13 ) {
+								insert_selected_media('img', src, data.u);
+							}
 						}).appendTo(list_container);
 
 						found++;
@@ -493,7 +497,7 @@
 					return;
 				}
 
-				media_container.removeClass('no-media').addClass( 'all-media--visible');
+				media_container.removeClass( 'no-media' ).addClass( 'all-media--visible' );
 			}
 
 /* ***************************************************************
@@ -506,17 +510,36 @@
 					$postOptions = $( '.post-options'),
 					$postOption = $( '.post-option'),
 					$settingModal = $( '.setting-modal' );
+					$modalClose = $( '.modal-close' );
 
-				$postOption.on('click', function() {
-					var index = $( this ).index();
+				$postOption.on( 'click', function() {
+					
+					var index = $( this ).index(),
+						$targetSettingModal = $settingModal.eq( index );
+
 					$postOptions.addClass( is_hidden );
-					$settingModal.eq( index ).addClass( is_active );
+					$targetSettingModal.addClass( is_active );
+
+					// Keyboard navigation
+	 				$postOption.attr( 'tabindex', '-1' );
+					$targetSettingModal.find( 'a, input' ).attr( 'tabindex', '0' );
+
 				});
 
-				$('.modal-close').click(function(){
-					$settingModal.removeClass( is_active );
+				$modalClose.on( 'click', function(){
+
+					var index = $( this ).parent().index();
+
 					$postOptions.removeClass( is_hidden );
-				});
+					$settingModal.removeClass( is_active );
+
+					// Keyboard navigation
+	 				$postOption.attr( 'tabindex', '0' );
+					$settingModal.find( 'a, input' ).attr( 'tabindex', '-1' );
+
+					$postOption.eq( index ).focus();
+
+				});	
 			}
 
 			function monitor_sidebar_toggle() {
@@ -563,6 +586,17 @@
 
 			}
 
+/* ***************************************************************
+ * KEYBOARD NAVIGATION FUNCTIONS
+ *************************************************************** */
+
+ 			function setTabIndex() {
+
+ 				$( '.setting-modal' ).find( 'a, input' ).attr( 'tabindex', '-1' );
+
+ 			}
+
+ 			setTabIndex();
 
 /* ***************************************************************
  * PROCESSING FUNCTIONS

--- a/js/tag-box.js
+++ b/js/tag-box.js
@@ -82,8 +82,13 @@
 
 				// If tags editing isn't disabled, create the X button.
 				if ( ! disabled ) {
-					xbutton = $( '<a id="' + id + '-check-num-' + key + '" class="ntdelbutton">X</a>' );
-					xbutton.click( function(){ tagBox.parseTags(this); });
+					xbutton = $( '<a id="' + id + '-check-num-' + key + '" class="ntdelbutton" tabindex="0">X</a>' );
+					xbutton.on( 'click keypress', function(e){ 
+						// Trigger function if pressed Enter - keyboard navigation
+						if ( e.which === 13 ) {
+							tagBox.parseTags(this);
+						}
+					});
 					span.prepend('&nbsp;').prepend( xbutton );
 				}
 

--- a/press-this.php
+++ b/press-this.php
@@ -794,8 +794,6 @@ class WpPressThis {
 		<div class="post-actions">
 			<button type="button" class="button--subtle" id="wppt_draft_field"><?php _e( 'Save Draft' ); ?></button>
 			<button type="button" class="button--primary" id="wppt_publish_field"><?php _e( 'Publish' ); ?></button>
-			<input type="submit" class="button--subtle" name="pressthis-draft" id="wppt_draft_field" value="<?php esc_attr_e( 'Save Draft' ); ?>" />
-			<input type="submit" class="button--primary" name="pressthis-publish" id="wppt_publish_field" value="<?php esc_attr_e( 'Publish' ); ?>" />
 		</div>
 	</div>
 	</form>

--- a/press-this.php
+++ b/press-this.php
@@ -684,7 +684,7 @@ class WpPressThis {
 	<div id="wppt_adminbar" class="adminbar">
 		<h1 id="wppt_current_site" class="current-site">
 			<span class="dashicons dashicons-wordpress"></span>
-			<a href="<?php echo esc_url( home_url( '/' ) ); ?>" target="_blank"><?php bloginfo( 'name' ); ?></a>
+			<a href="<?php echo esc_url( home_url( '/' ) ); ?>" target="_blank" tabindex="-1"><?php bloginfo( 'name' ); ?></a>
 		</h1>
 		<button class="options-open button--subtle"><span class="dashicons dashicons-tag"></span><span class="screen-reader-text"><?php _e( 'Show post options' ); ?></span></button>
 		<button class="options-close button--subtle is-hidden"><?php _e( 'Done' ); ?></button>
@@ -707,7 +707,7 @@ class WpPressThis {
 		<div class="editor-wrapper">
 			<div id='wppt_app_container' class="editor">
 				<span id="wppt_title_container_label" class="post__title-placeholder"><?php _e( 'Post title' ); ?></span>
-				<h2 id="wppt_title_container" class="post__title" contenteditable="true" spellcheck="true" aria-labelledby="wppt_title_container_label"></h2>
+				<h2 id="wppt_title_container" class="post__title" contenteditable="true" spellcheck="true" aria-labelledby="wppt_title_container_label" tabindex="0"></h2>
 				<div id='wppt_featured_media_container' class="featured-container no-media">
 					<div id='wppt_all_media_widget' class="all-media">
 						<div id='wppt_all_media_container'></div>
@@ -742,20 +742,20 @@ class WpPressThis {
 		<div class="options-panel">
 			<div class="post-options">
 				<?php if ( $supports_formats ) : ?>
-					<a href="#" class="post-option">
+					<a href="#" class="post-option" tabindex="0">
 						<span class="dashicons dashicons-admin-post"></span>
 						<span class="post-option__title"><?php _e('Format'); ?></span>
 						<span class="post-option__contents" id="post-option-post-format"><?php echo esc_html( get_post_format_string( $post_format ) ); ?></span>
 						<span class="dashicons dashicons-arrow-right-alt2"></span>
 					</a>
 				<?php endif; ?>
-				<a href="#" class="post-option">
+				<a href="#" class="post-option" tabindex="0">
 					<span class="dashicons dashicons-category"></span>
 					<span class="post-option__title"><?php _e('Categories'); ?></span>
 					<span class="post-option__contents" id="post-option-category"></span>
 					<span class="dashicons dashicons-arrow-right-alt2"></span>
 				</a>
-				<a href="#" class="post-option">
+				<a href="#" class="post-option" tabindex="0">
 					<span class="dashicons dashicons-tag"></span>
 					<span class="post-option__title"><?php _e('Tags'); ?></span>
 					<span class="post-option__contents" id="post-option-tags"></span>
@@ -765,20 +765,20 @@ class WpPressThis {
 
 			<?php if ( $supports_formats ) : ?>
 				<div class="setting-modal">
-					<a href="#" class="modal-close"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Post format'); ?></span></a>
+					<a href="#" class="modal-close" tabindex="-1"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Post format'); ?></span></a>
 					<?php post_format_meta_box( $post, null ); ?>
 				</div>
 			<?php endif; ?>
 
 			<div class="setting-modal">
-				<a href="#" class="modal-close"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Categories'); ?></span></a>
+				<a href="#" class="modal-close" tabindex="-1"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Categories'); ?></span></a>
 				<ul class="categories-select">
 					<?php wp_terms_checklist( $post->ID, array( 'taxonomy' => 'category' ) ); ?>
 				</ul>
 			</div>
 
 			<div class="setting-modal tags">
-				<a href="#" class="modal-close"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Tags'); ?></span></a>
+				<a href="#" class="modal-close" tabindex="-1"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Tags'); ?></span></a>
 				<?php post_tags_meta_box( $post, null ); ?>
 			</div>
 		</div><!-- .options-panel -->
@@ -786,7 +786,7 @@ class WpPressThis {
 
 	<div class="press-this__actions">
 		<div class="pressthis-media-buttons">
-			<button type="button" class="insert-media button--subtle" data-editor="pressthis">
+			<button type="button" class="insert-media button--subtle" data-editor="pressthis" tabindex="0">
 				<span class="dashicons dashicons-camera"></span>
 				<span class="screen-reader-text"><?php _e( 'Add Media' ); ?></span>
 			</button>

--- a/press-this.php
+++ b/press-this.php
@@ -684,7 +684,7 @@ class WpPressThis {
 	<div id="wppt_adminbar" class="adminbar">
 		<h1 id="wppt_current_site" class="current-site">
 			<span class="dashicons dashicons-wordpress"></span>
-			<a href="<?php echo esc_url( home_url( '/' ) ); ?>" target="_blank" tabindex="-1"><?php bloginfo( 'name' ); ?></a>
+			<span><?php bloginfo( 'name' ); ?></span>
 		</h1>
 		<button class="options-open button--subtle"><span class="dashicons dashicons-tag"></span><span class="screen-reader-text"><?php _e( 'Show post options' ); ?></span></button>
 		<button class="options-close button--subtle is-hidden"><?php _e( 'Done' ); ?></button>
@@ -742,20 +742,20 @@ class WpPressThis {
 		<div class="options-panel">
 			<div class="post-options">
 				<?php if ( $supports_formats ) : ?>
-					<a href="#" class="post-option" tabindex="0">
+					<a href="#" class="post-option">
 						<span class="dashicons dashicons-admin-post"></span>
 						<span class="post-option__title"><?php _e('Format'); ?></span>
 						<span class="post-option__contents" id="post-option-post-format"><?php echo esc_html( get_post_format_string( $post_format ) ); ?></span>
 						<span class="dashicons dashicons-arrow-right-alt2"></span>
 					</a>
 				<?php endif; ?>
-				<a href="#" class="post-option" tabindex="0">
+				<a href="#" class="post-option">
 					<span class="dashicons dashicons-category"></span>
 					<span class="post-option__title"><?php _e('Categories'); ?></span>
 					<span class="post-option__contents" id="post-option-category"></span>
 					<span class="dashicons dashicons-arrow-right-alt2"></span>
 				</a>
-				<a href="#" class="post-option" tabindex="0">
+				<a href="#" class="post-option">
 					<span class="dashicons dashicons-tag"></span>
 					<span class="post-option__title"><?php _e('Tags'); ?></span>
 					<span class="post-option__contents" id="post-option-tags"></span>
@@ -786,7 +786,7 @@ class WpPressThis {
 
 	<div class="press-this__actions">
 		<div class="pressthis-media-buttons">
-			<button type="button" class="insert-media button--subtle" data-editor="pressthis" tabindex="0">
+			<button type="button" class="insert-media button--subtle" data-editor="pressthis">
 				<span class="dashicons dashicons-camera"></span>
 				<span class="screen-reader-text"><?php _e( 'Add Media' ); ?></span>
 			</button>
@@ -794,6 +794,8 @@ class WpPressThis {
 		<div class="post-actions">
 			<button type="button" class="button--subtle" id="wppt_draft_field"><?php _e( 'Save Draft' ); ?></button>
 			<button type="button" class="button--primary" id="wppt_publish_field"><?php _e( 'Publish' ); ?></button>
+			<input type="submit" class="button--subtle" name="pressthis-draft" id="wppt_draft_field" value="<?php esc_attr_e( 'Save Draft' ); ?>" />
+			<input type="submit" class="button--primary" name="pressthis-publish" id="wppt_publish_field" value="<?php esc_attr_e( 'Publish' ); ?>" />
 		</div>
 	</div>
 	</form>

--- a/scss/components/_categories.scss
+++ b/scss/components/_categories.scss
@@ -30,14 +30,21 @@
 		min-width: 16px;
 		-webkit-appearance: none;
 		appearance: none;
+		width: 100%;
+		position: absolute;
+		bottom: 0;
+		left: 0;
+
+		&:focus {
+			border-bottom: 3px solid $blue--light;
+		}
 
 		&:checked:after {
 			display: inline-block;
 			content: "\f147";
 			position: absolute;
-				top: 50%;
+				top: -1.65em;
 				right: 15px;
-			margin-top: -10px;
 			width: 20px;
 			height: 20px;
 			margin-right: 10px;

--- a/scss/components/_categories.scss
+++ b/scss/components/_categories.scss
@@ -30,14 +30,6 @@
 		min-width: 16px;
 		-webkit-appearance: none;
 		appearance: none;
-		width: 100%;
-		position: absolute;
-		bottom: 0;
-		left: 0;
-
-		&:focus {
-			border-bottom: 3px solid $blue--light;
-		}
 
 		&:checked:after {
 			display: inline-block;

--- a/scss/components/_post-formats.scss
+++ b/scss/components/_post-formats.scss
@@ -12,7 +12,8 @@
 .post-format { // TODO make accessible
 	width: 0;
 	height: 0;
-	float: left;
+	position: absolute;
+	top: -9999px; // TODO find a better way for hidding it
 }
 
 .post-format-icon {

--- a/scss/components/_post-formats.scss
+++ b/scss/components/_post-formats.scss
@@ -10,7 +10,9 @@
 }
 
 .post-format { // TODO make accessible
-	display: none;
+	width: 0;
+	height: 0;
+	float: left;
 }
 
 .post-format-icon {

--- a/scss/components/_tags.scss
+++ b/scss/components/_tags.scss
@@ -19,11 +19,6 @@
 		border: 0;
 		border-bottom: 1px solid $gray--light;
 		font-size: 16px;
-
-		&:focus {
-			@extend %focus-box-shadow;
-		}
-
 	}
 	.tagadd {
 		position: absolute;
@@ -35,6 +30,7 @@
 		background: $gray--light;
 
 		&:focus {
+			outline: 0;
 			background: $blue--light;
 			color: #fff;
 		}
@@ -148,7 +144,7 @@ input.newtag:focus ~ div.taghint {
 		}
 
 		&:focus:before {
-			color: $blue--light;
+			color: map-get( $link-color, color--hover );
 		}
 
 	}
@@ -164,11 +160,6 @@ input.newtag:focus ~ div.taghint {
 	padding: 0 16px;
 	text-decoration: none;
 	outline: 0;
-
-	&:focus {
-		@extend %focus-box-shadow;
-	}
-
 }
 
 .popular-tags {
@@ -189,11 +180,6 @@ input.newtag:focus ~ div.taghint {
 	a {
 		text-decoration: none;
 		outline: 0;
-
-		&:focus {
-			@extend %focus-box-shadow;
-		}		
-
 	}
 }
 

--- a/scss/components/_tags.scss
+++ b/scss/components/_tags.scss
@@ -19,6 +19,11 @@
 		border: 0;
 		border-bottom: 1px solid $gray--light;
 		font-size: 16px;
+
+		&:focus {
+			@extend %focus-box-shadow;
+		}
+
 	}
 	.tagadd {
 		position: absolute;
@@ -28,6 +33,12 @@
 		border: 0;
 		padding: 0 16px;
 		background: $gray--light;
+
+		&:focus {
+			background: $blue--light;
+			color: #fff;
+		}
+
 	}
 	.howto {
 		color: $gray--middle;
@@ -120,6 +131,7 @@ input.newtag:focus ~ div.taghint {
 		text-indent: 0;
 		overflow: hidden;
 		position: absolute;
+		outline: 0;
 
 		&:before {
 			content: '\f153';
@@ -134,6 +146,11 @@ input.newtag:focus ~ div.taghint {
 			speak: none;
 			-webkit-font-smoothing: antialiased!important
 		}
+
+		&:focus:before {
+			color: $blue--light;
+		}
+
 	}
 }
 
@@ -146,6 +163,12 @@ input.newtag:focus ~ div.taghint {
 	display: block;
 	padding: 0 16px;
 	text-decoration: none;
+	outline: 0;
+
+	&:focus {
+		@extend %focus-box-shadow;
+	}
+
 }
 
 .popular-tags {
@@ -165,6 +188,12 @@ input.newtag:focus ~ div.taghint {
 
 	a {
 		text-decoration: none;
+		outline: 0;
+
+		&:focus {
+			@extend %focus-box-shadow;
+		}		
+
 	}
 }
 

--- a/scss/components/buttons/_extends.scss
+++ b/scss/components/buttons/_extends.scss
@@ -26,12 +26,3 @@ $button-types: secondary, primary;
 		@include button( map-get( $buttons, #{$item}__background ), map-get( $buttons, #{$item}__color ) );
 	}
 }
-
-// ==========================================================================
-// State extends
-// ==========================================================================
-
-// Focus
-%focus-box-shadow {
-	box-shadow: inset 0px -5px 0 $blue--light;
-}

--- a/scss/components/buttons/_extends.scss
+++ b/scss/components/buttons/_extends.scss
@@ -26,3 +26,12 @@ $button-types: secondary, primary;
 		@include button( map-get( $buttons, #{$item}__background ), map-get( $buttons, #{$item}__color ) );
 	}
 }
+
+// ==========================================================================
+// State extends
+// ==========================================================================
+
+// Focus
+%focus-box-shadow {
+	box-shadow: inset 0px -5px 0 $blue--light;
+}

--- a/scss/views/_main.scss
+++ b/scss/views/_main.scss
@@ -77,20 +77,12 @@ body {
 		color: #404040;
 		font-size: 14px;
 	}
-	a {
+	span {
 		color: #ededed;
-		text-decoration: none;
 
-		&:hover {
-			color: #fff;
-		}
 		@include breakpoint( '<320px' ) {
 			color: #3f3f3f;
 			font-weight: 600;
-
-			&:hover {
-				color: $blue--light;
-			}
 		}
 	}
 	.dashicons-wordpress {
@@ -171,11 +163,6 @@ body {
 	padding: em( 12px, 14px ) em( 15px, 14px );
 	font-size: 14px;
 	width: 100%;
-
-	&:focus {
-		@extend %focus-box-shadow;
-	}
-
 }
 .scan__submit {
 	@extend %button;
@@ -260,7 +247,8 @@ body {
 
 	&:active,
 	&:focus {
-		@extend %focus-box-shadow;
+		outline: 0;
+		box-shadow: inset 0px -5px 0 $blue--light;
 		border-color: $blue--light;
 	}
 	@media ( max-height: 400px ) {
@@ -553,7 +541,13 @@ body {
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
-		transition: all .3s ease-in-out;
+		transition: transform .3s ease-in-out;
+
+		&:focus {
+			outline: 0;
+			box-shadow: inset 5px 0 0 $blue--light;
+		}
+
 	}
 	.is-hidden & {
 		right: 100%;
@@ -604,7 +598,8 @@ body {
 	text-decoration: none;
 
 	&:focus {
-		@extend %focus-box-shadow;
+		outline: 0;
+		box-shadow: inset 5px 0 0 $blue--light;
 	}
 
 }

--- a/scss/views/_main.scss
+++ b/scss/views/_main.scss
@@ -326,10 +326,6 @@ body {
 	background-size: cover;
 	cursor: pointer;
 
-	&:focus {
-		@extend %focus-box-shadow;
-	}
-
 	@include breakpoint ( '>600px' ) {
 		$size: 12.5%;
 		width: $size;

--- a/scss/views/_main.scss
+++ b/scss/views/_main.scss
@@ -171,6 +171,11 @@ body {
 	padding: em( 12px, 14px ) em( 15px, 14px );
 	font-size: 14px;
 	width: 100%;
+
+	&:focus {
+		@extend %focus-box-shadow;
+	}
+
 }
 .scan__submit {
 	@extend %button;
@@ -255,8 +260,7 @@ body {
 
 	&:active,
 	&:focus {
-		outline: 0;
-		box-shadow: inset 0px -3px 0 $blue--light;
+		@extend %focus-box-shadow;
 		border-color: $blue--light;
 	}
 	@media ( max-height: 400px ) {
@@ -333,6 +337,10 @@ body {
 	background-repeat: no-repeat;
 	background-size: cover;
 	cursor: pointer;
+
+	&:focus {
+		@extend %focus-box-shadow;
+	}
 
 	@include breakpoint ( '>600px' ) {
 		$size: 12.5%;
@@ -594,6 +602,11 @@ body {
 	padding: 13px 14px; // TODO em()
 	border-bottom: 1px solid $gray--light;
 	text-decoration: none;
+
+	&:focus {
+		@extend %focus-box-shadow;
+	}
+
 }
 
 .setting-title {


### PR DESCRIPTION
This commit adds JS logic to handle the `tabindex` of diverse elements
that are dinamically loaded/displayed in Press This.

Also adds basic styles for the :focus state.

Example navigation:

![press-this-issue-67](https://cloud.githubusercontent.com/assets/384622/6201532/fd7dc664-b4af-11e4-988e-91918a096391.gif)
