### PR TITLE
Update/issue 67. Keyboard Navigation.

### DIFF
--- a/css/press-this.css
+++ b/css/press-this.css
@@ -1511,17 +1511,20 @@ html {
     position: absolute;
     top: 0;
     right: 0;
-    -webkit-transform: translateX(0);
-    -ms-transform: translateX(0);
-    transform: translateX(0);
-    -webkit-transition: -webkit-transform .3s ease-in-out;
-    transition: transform .3s ease-in-out;
     background: #fff;
-  }
-  .options-panel.is-open {
     -webkit-transform: translateX(-100%);
     -ms-transform: translateX(-100%);
     transform: translateX(-100%);
+    -webkit-transition: -webkit-transform .3s ease-in-out;
+    transition: transform .3s ease-in-out;
+  }
+  .options-panel.is-hidden {
+    visibility: hidden;
+  }
+  .options-panel.is-off-screen {
+    -webkit-transform: translateX(0);
+    -ms-transform: translateX(0);
+    transform: translateX(0);
   }
 }
 
@@ -1563,11 +1566,14 @@ html {
   -webkit-box-shadow: inset 5px 0 0 #2ea2cc;
   box-shadow: inset 5px 0 0 #2ea2cc;
 }
-.is-hidden .post-option {
+.is-off-screen > .post-option {
   right: 100%;
 }
+.is-hidden > .post-option {
+  visibility: hidden;
+}
 @media (min-width: 1px) {
-  .is-hidden .post-option {
+  .is-off-screen > .post-option {
     right: auto;
     -webkit-transform: translateX(-100%);
     -ms-transform: translateX(-100%);
@@ -1585,29 +1591,26 @@ html {
 .setting-modal {
   position: absolute;
   top: 0;
-  left: 100%;
+  left: 0;
   width: 100%;
-  height: 0;
+  height: auto;
   overflow: hidden;
   -webkit-transition: -webkit-transform .3s ease-in-out;
   transition: transform .3s ease-in-out;
 }
-.setting-modal.is-active {
-  left: 0;
-  height: auto;
-  overflow: hidden;
+.setting-modal.is-hidden {
+  visibility: hidden;
+  height: 0;
+}
+.setting-modal.is-off-screen {
+  left: 100%;
 }
 @media (min-width: 1px) {
-  .setting-modal {
+  .setting-modal.is-off-screen {
     left: 0;
     -webkit-transform: translateX(100%);
     -ms-transform: translateX(100%);
     transform: translateX(100%);
-  }
-  .setting-modal.is-active {
-    -webkit-transform: translateX(0);
-    -ms-transform: translateX(0);
-    transform: translateX(0);
   }
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -677,10 +677,11 @@
 			 */
 			function monitor_options_modal() {
 				var is_active = 'is-active',
+					is_off_screen = 'is-off-screen',
 					is_hidden = 'is-hidden',
-					$postOptions = $( '.post-options'),
-					$postOption = $( '.post-option'),
-					$settingModal = $( '.setting-modal'),
+					$postOptions = $( '.post-options' ),
+					$postOption = $( '.post-option' ),
+					$settingModal = $( '.setting-modal' ),
 					$modalClose = $( '.modal-close' );
 
 				$postOption.on( 'click', function() {
@@ -688,19 +689,35 @@
 					var index = $( this ).index(),
 						$targetSettingModal = $settingModal.eq( index );
 
-					$postOptions.addClass( is_hidden );
-					$targetSettingModal.addClass( is_active );
+					$postOptions
+						.addClass( is_off_screen )
+						.one( 'transitionend', function() {
+							$( this ).addClass( is_hidden );
+						});
+
+					$targetSettingModal
+						.removeClass( is_off_screen + ' ' + is_hidden )
+						.one( 'transitionend', function() {
+							$( this ).find( $modalClose ).focus();
+						});
 
 				});
 
 				$modalClose.on( 'click', function(){
 
-					var index = $( this ).parent().index();
+					var $targetSettingModal = $( this ).parent();
+						index = $targetSettingModal.index();
 
-					$postOptions.removeClass( is_hidden );
-					$settingModal.removeClass( is_active );
+					$postOptions
+						.removeClass( is_off_screen + ' ' + is_hidden );
+					
+					$targetSettingModal
+						.addClass( is_off_screen )
+						.one( 'transitionend', function() {
+							$( this ).addClass( is_hidden );
+						});;
 
-					$postOption.eq( index ).focus();
+					$postOption.eq( index - 1 ).focus();
 
 				});
 			}
@@ -711,22 +728,35 @@
 			function monitor_sidebar_toggle() {
 				var $opt_open  = $( '.options-open' ),
 					$opt_close = $( '.options-close' ),
+					$postOptions = $( '.post-options' ),
+					$postOption = $( '.post-option' ),
+					$settingModal = $( '.setting-modal' ),
 					$sidebar = $( '.options-panel' ),
-					is_open = 'is-open',
+					is_off_screen = 'is-off-screen',
 					is_hidden = 'is-hidden';
 
-				$opt_open.click(function(){
+				$opt_open.on( 'click', function(){
+
 					$opt_open.addClass( is_hidden );
 					$opt_close.removeClass( is_hidden );
-					$sidebar.addClass( is_open );
+
+					$sidebar
+						.removeClass( is_off_screen + ' ' + is_hidden )
+						.one( 'transitionend', function() {
+							$postOption.eq(0).focus();
+						});					
 				});
 
-				$opt_close.click(function(){
+				$opt_close.on( 'click', function(){
+
 					$opt_close.addClass( is_hidden );
 					$opt_open.removeClass( is_hidden );
-					$sidebar.removeClass( is_open );
-					$( '.post-options' ).removeClass( is_hidden );
-					$( '.setting-modal').removeClass( 'is-active' );
+						
+					$sidebar
+						.addClass( is_off_screen )
+						.one( 'transitionend', function() {
+							$( this ).addClass( is_hidden );
+						});;					
 				});
 			}
 

--- a/js/app.js
+++ b/js/app.js
@@ -691,10 +691,6 @@
 					$postOptions.addClass( is_hidden );
 					$targetSettingModal.addClass( is_active );
 
-					// Keyboard navigation
-	 				$postOption.attr( 'tabindex', '-1' );
-					$targetSettingModal.find( 'a, input' ).attr( 'tabindex', '0' );
-
 				});
 
 				$modalClose.on( 'click', function(){
@@ -703,10 +699,6 @@
 
 					$postOptions.removeClass( is_hidden );
 					$settingModal.removeClass( is_active );
-
-					// Keyboard navigation
-	 				$postOption.attr( 'tabindex', '0' );
-					$settingModal.find( 'a, input' ).attr( 'tabindex', '-1' );
 
 					$postOption.eq( index ).focus();
 
@@ -762,19 +754,6 @@
 			}
 
 /* ***************************************************************
- * KEYBOARD NAVIGATION FUNCTIONS
- *************************************************************** */
-
-			/**
-			 * Set tab index
-			 */
-			function setTabIndex() {
-
- 				$( '.setting-modal' ).find( 'a, input' ).attr( 'tabindex', '-1' );
-
- 			}
-
-/* ***************************************************************
  * PROCESSING FUNCTIONS
  *************************************************************** */
 
@@ -788,7 +767,6 @@
 				render_detected_media();
 				$( document ).on( 'tinymce-editor-init', render_suggested_content );
 				render_startup_notices();
-				setTabIndex();
 			}
 
 			/**

--- a/press-this.php
+++ b/press-this.php
@@ -740,7 +740,7 @@ class WpPressThis {
 			</div>
 		</div>
 
-		<div class="options-panel">
+		<div class="options-panel is-off-screen is-hidden">
 			<div class="post-options">
 				<?php if ( $supports_formats ) : ?>
 					<a href="#" class="post-option">
@@ -765,13 +765,13 @@ class WpPressThis {
 			</div>
 
 			<?php if ( $supports_formats ) : ?>
-				<div class="setting-modal">
+				<div class="setting-modal is-off-screen is-hidden">
 					<a href="#" class="modal-close"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Post format'); ?></span></a>
 					<?php post_format_meta_box( $post, null ); ?>
 				</div>
 			<?php endif; ?>
 
-			<div class="setting-modal">
+			<div class="setting-modal is-off-screen is-hidden">
 				<a href="#" class="modal-close"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Categories'); ?></span></a>
 				<?php
 
@@ -806,7 +806,7 @@ class WpPressThis {
 				</ul>
 			</div>
 
-			<div class="setting-modal tags">
+			<div class="setting-modal tags is-off-screen is-hidden">
 				<a href="#" class="modal-close"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Tags'); ?></span></a>
 				<?php post_tags_meta_box( $post, null ); ?>
 			</div>

--- a/press-this.php
+++ b/press-this.php
@@ -766,13 +766,13 @@ class WpPressThis {
 
 			<?php if ( $supports_formats ) : ?>
 				<div class="setting-modal">
-					<a href="#" class="modal-close" tabindex="-1"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Post format'); ?></span></a>
+					<a href="#" class="modal-close"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Post format'); ?></span></a>
 					<?php post_format_meta_box( $post, null ); ?>
 				</div>
 			<?php endif; ?>
 
 			<div class="setting-modal">
-				<a href="#" class="modal-close" tabindex="-1"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Categories'); ?></span></a>
+				<a href="#" class="modal-close"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Categories'); ?></span></a>
 				<?php
 
 				$taxonomy = get_taxonomy( 'category' );
@@ -807,7 +807,7 @@ class WpPressThis {
 			</div>
 
 			<div class="setting-modal tags">
-				<a href="#" class="modal-close" tabindex="-1"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Tags'); ?></span></a>
+				<a href="#" class="modal-close"><span class="dashicons dashicons-arrow-left-alt2"></span><span class="setting-title"><?php _e('Tags'); ?></span></a>
 				<?php post_tags_meta_box( $post, null ); ?>
 			</div>
 		</div><!-- .options-panel -->

--- a/scss/views/_main.scss
+++ b/scss/views/_main.scss
@@ -509,13 +509,18 @@ body {
 		position: absolute;
 		top: 0;
 		right: 0;
-		transform: translateX( 0 );
-		transition: transform .3s ease-in-out;
 		background: #fff;
+		transform: translateX( -100% );
+		transition: transform .3s ease-in-out;
 
-		&.is-open {
-			transform: translateX( -100% );
+		&.is-hidden {
+			visibility: hidden;
 		}
+
+		&.is-off-screen {
+			transform: translateX( 0 );
+		}	
+
 	}
 }
 
@@ -536,6 +541,7 @@ body {
 			right: 8px;
 		margin-top: -10px;
 	}
+
 }
 
 .post-option {
@@ -558,15 +564,22 @@ body {
 		}
 
 	}
-	.is-hidden & {
+
+	.is-off-screen > & {
 		right: 100%;
 	}
+
+	.is-hidden > & {
+		visibility: hidden;
+	}
+
 	@media ( min-width: 1px ) {
-		.is-hidden & {
+		.is-off-screen > & {
 			right: auto;
 			transform: translateX( -100% );
 		}
 	}
+
 }
 
 .post-option__title {
@@ -579,25 +592,30 @@ body {
 .setting-modal {
 	position: absolute;
 		top: 0;
-		left: 100%;
+		left: 0;
 	width: 100%;
-	height: 0;
+	height: auto;
 	overflow: hidden;
 	transition: transform .3s ease-in-out;
 
-	&.is-active {
-		left: 0;
-		height: auto;
-		overflow: hidden;
+	&.is-hidden {
+		visibility: hidden;
+		height: 0;
 	}
-	@media ( min-width: 1px ) {
-		left: 0;
-			transform: translateX( 100% );
 
-		&.is-active {
-			transform: translateX( 0 );
-		}
+	&.is-off-screen {
+		left: 100%;
 	}
+
+	@media ( min-width: 1px ) {
+
+		&.is-off-screen {
+			left: 0;
+				transform: translateX( 100% );
+		}
+
+	}
+
 }
 
 .modal-close {


### PR DESCRIPTION
Removing unnecessary handlers for tabindex. We are going to manage the tabindex with the visibility of the elements.

I replaced some of the old classes to keep consistency (we had `is-open`, `is-active`, etc).

Some of the declarations are inverted to play well with these new classes. The idea is not to mix 'is-hidden' and  'is-visible' or 'is-off-screen' and 'is-on-screen'.

In order to achieve this, the styles were changed:
- All the elements without any of this modifier classes retain their
"visible" and "on screen" state.
- Some of the elements start with the classes `is-hidden` and `is-off-screen`.