### PR TITLE
#66. Solving clicking through the title to edit it in IE8.

### DIFF
--- a/css/press-this.css
+++ b/css/press-this.css
@@ -1380,6 +1380,10 @@ html {
   }
 }
 
+.post__title {
+  background: url(data:image/gif;base64,R0lGODlhAQABAJEAAAAAAP///////wAAACH5BAEHAAIALAAAAAABAAEAAAICVAEAOw==);
+  background: none, none;
+}
 .post__title:before {
   content: '\a0';
   display: inline-block;

--- a/scss/views/_main.scss
+++ b/scss/views/_main.scss
@@ -273,6 +273,12 @@ body {
 }
 
 .post__title {
+
+	// This is a 1px transparent gif to get a click-through behavior on IE8
+	background: url(data:image/gif;base64,R0lGODlhAQABAJEAAAAAAP///////wAAACH5BAEHAAIALAAAAAABAAEAAAICVAEAOw==);
+	// IE8 doesn't support multiple backgrounds, so it'll ignore the following
+	background: none, none;
+
 	&:before {
 		// Keeps empty container from collapsing
 		content: '\a0';


### PR DESCRIPTION
We are doing a fake placeholder for the title. The structure looks something like:
```
<span class="placeholder">Post title</span>
<h2 contenteditable="true">
```
The span has a `z-index` of `-1`, to position it below the `h2` and let it get focus on click. This trick doesn't work in IE8, because the `h2` doesn't have a background.

This commit adds a dumb 1px transparent .gif as background for the `h2`, in the form of a data-uri. This solves the issue of IE8.