### PR TITLE
Intent of canonical tag should be respected

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -62,15 +62,15 @@
 				}
 
 				var link = '';
-
-				if ( data.u ) {
-					link = data.u;
-				}
-
-				if ( ! link.length && data._links ) {
+				
+				if ( data._links ) {
 					if (data._links.canonical && data._links.canonical.length) {
 						link = data._links.canonical;
-					}
+					}	
+				}
+
+				if ( ! link.length && data.u ) {
+					link = data.u;
 				}
 
 				if ( ! link.length && data._meta ) {

--- a/js/bookmarklet.js
+++ b/js/bookmarklet.js
@@ -92,7 +92,6 @@
 		if ( g_rel ) {
 			switch ( g_rel ) {
 				case 'canonical':
-					add( '_links[' + g_rel + ']', g.getAttribute( 'href' ) );
 				case 'icon':
 				case 'shortlink':
 					add( '_links[' + g_rel + ']', g.getAttribute( 'href' ) );

--- a/js/bookmarklet.js
+++ b/js/bookmarklet.js
@@ -92,6 +92,7 @@
 		if ( g_rel ) {
 			switch ( g_rel ) {
 				case 'canonical':
+					add( '_links[' + g_rel + ']', g.getAttribute( 'href' ) );
 				case 'icon':
 				case 'shortlink':
 					add( '_links[' + g_rel + ']', g.getAttribute( 'href' ) );


### PR DESCRIPTION
These changes move to respect the canonical tag as the primary arbitrator for the question "what is my URL?". Looking at current uses across sites and social networks as well as the recommended uses from Google, the canonical tag should be considered the primary URL for any page if supplied, even over the current URL. 

@MichaelArestad Hopefully I changed this code correctly? I'm not completely sure I did. I saw there was a canonical property for `_links` that wasn't being filled and assumed it just hadn't been done yet, hopefully I was right? 