### PR TITLE
use aria-label directly on the post title heading

### DIFF
--- a/press-this.php
+++ b/press-this.php
@@ -929,8 +929,7 @@ class WP_Press_This {
 			</div>
 
 			<div id='wppt_app_container' class="editor">
-				<span id="wppt_title_container_label" class="post-title-placeholder"><?php _e( 'Post title' ); ?></span>
-				<h2 id="wppt_title_container" class="post-title" contenteditable="true" spellcheck="true" aria-labelledby="wppt_title_container_label" tabindex="0"></h2>
+				<h2 id="wppt_title_container" class="post-title" contenteditable="true" spellcheck="true" aria-label="<?php _e( 'Post title' ); ?>" tabindex="0"></h2>
 				<div id='wppt_featured_media_container' class="featured-container no-media">
 					<div id='wppt_all_media_widget' class="all-media">
 						<div id='wppt_all_media_container'></div>


### PR DESCRIPTION
avoid Post Title to be read out twice by screen readers and remove the
span targeted by aria-labelledby